### PR TITLE
Update iTerm2 profile and add dedent script

### DIFF
--- a/apps/iterm2/profile.json
+++ b/apps/iterm2/profile.json
@@ -1,401 +1,621 @@
 {
-  "Link Color" : {
-    "Red Component" : 0,
+  "Ansi 7 Color (Light)" : {
+    "Red Component" : 0.97250000000000003,
     "Color Space" : "sRGB",
-    "Blue Component" : 0.73423302173614502,
+    "Blue Component" : 0.94899999999999995,
     "Alpha Component" : 1,
-    "Green Component" : 0.35916060209274292
+    "Green Component" : 0.97250000000000003
   },
-  "Tags" : [
-
-  ],
-  "Ansi 12 Color" : {
-    "Red Component" : 0.31227968847822024,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.58540481328964233,
+  "Ansi 15 Color (Light)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
     "Alpha Component" : 1,
-    "Green Component" : 0.41903274693207082
+    "Green Component" : 1
   },
-  "Ansi 7 Color" : {
-    "Red Component" : 0.84917535745736328,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.81944967499937305,
+  "Right Option Key Changeable" : true,
+  "Bold Color" : {
+    "Red Component" : 0.062745101749897003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.062745101749897003,
     "Alpha Component" : 1,
-    "Green Component" : 0.84734719453193297
+    "Green Component" : 0.062745101749897003
+  },
+  "Ansi 1 Color (Dark)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.33329999999999999,
+    "Alpha Component" : 1,
+    "Green Component" : 0.33329999999999999
+  },
+  "Use Bright Bold" : true,
+  "Ansi 9 Color (Light)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.43140000000000001,
+    "Alpha Component" : 1,
+    "Green Component" : 0.43140000000000001
+  },
+  "Ansi 8 Color (Dark)" : {
+    "Red Component" : 0.38429999999999997,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.6431,
+    "Alpha Component" : 1,
+    "Green Component" : 0.4471
+  },
+  "Ansi 2 Color (Light)" : {
+    "Red Component" : 0.31369999999999998,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.4824,
+    "Alpha Component" : 1,
+    "Green Component" : 0.98040000000000005
+  },
+  "Background Color" : {
+    "Red Component" : 0.97999999999999998,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.97999999999999998,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97999999999999998
   },
   "Ansi 8 Color" : {
-    "Red Component" : 0.31372550129890442,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.32941177487373352,
+    "Red Component" : 0.40781760215759277,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.4078223705291748,
     "Alpha Component" : 1,
-    "Green Component" : 0.32549020648002625
+    "Green Component" : 0.40782788395881653
   },
-  "Bold Color" : {
+  "Columns" : 80,
+  "Right Option Key Sends" : 2,
+  "Ansi 4 Color (Light)" : {
+    "Red Component" : 0.74119999999999997,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.97650000000000003,
+    "Alpha Component" : 1,
+    "Green Component" : 0.57650000000000001
+  },
+  "Blinking Cursor" : false,
+  "Selected Text Color (Light)" : {
     "Red Component" : 1,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 1,
-    "Alpha Component" : 1,
-    "Green Component" : 1
-  },
-  "Ansi 9 Color" : {
-    "Red Component" : 0.55439623311334207,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.16595275307879542,
-    "Alpha Component" : 1,
-    "Green Component" : 1
-  },
-  "Horizontal Spacing" : 1,
-  "Right Option Key Sends" : 0,
-  "Rows" : 25,
-  "Default Bookmark" : "No",
-  "Cursor Guide Color" : {
-    "Red Component" : 0.70213186740875244,
     "Color Space" : "sRGB",
     "Blue Component" : 1,
-    "Alpha Component" : 0.25,
-    "Green Component" : 0.9268307089805603
-  },
-  "Non-ASCII Anti Aliased" : true,
-  "Use Bright Bold" : true,
-  "Ansi 10 Color" : {
-    "Red Component" : 0.28296446605181802,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.46514269413257492,
     "Alpha Component" : 1,
     "Green Component" : 1
   },
+  "Selected Text Color (Dark)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Ansi 3 Color (Dark)" : {
+    "Red Component" : 0.94510000000000005,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.54900000000000004,
+    "Alpha Component" : 1,
+    "Green Component" : 0.98040000000000005
+  },
+  "Keyboard Map" : {
+
+  },
+  "Visual Bell" : true,
+  "Cursor Text Color" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Scrollback Lines" : 1000,
+  "Selection Color (Light)" : {
+    "Red Component" : 0.26669999999999999,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.35289999999999999,
+    "Alpha Component" : 1,
+    "Green Component" : 0.27839999999999998
+  },
+  "Ansi 0 Color" : {
+    "Red Component" : 0.078431375324726105,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.11764705926179886,
+    "Alpha Component" : 1,
+    "Green Component" : 0.098039217293262482
+  },
+  "Match Background Color (Dark)" : {
+    "Red Component" : 0.99697142839431763,
+    "Color Space" : "P3",
+    "Blue Component" : 0.32116127014160156,
+    "Alpha Component" : 1,
+    "Green Component" : 0.98600882291793823
+  },
+  "Ansi 11 Color (Light)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.64710000000000001,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Ansi 5 Color (Dark)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.77649999999999997,
+    "Alpha Component" : 1,
+    "Green Component" : 0.47449999999999998
+  },
+  "Cursor Text Color (Light)" : {
+    "Red Component" : 0.15690000000000001,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.21179999999999999,
+    "Alpha Component" : 1,
+    "Green Component" : 0.16470000000000001
+  },
+  "Silence Bell" : false,
+  "Rows" : 25,
+  "Guid" : "A49767B5-746A-4D3B-A5E1-7F768EB1DEDA",
+  "Ansi 14 Color (Dark)" : {
+    "Red Component" : 0.6431,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Ansi 15 Color (Dark)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Ansi 0 Color (Dark)" : {
+    "Red Component" : 0.12939999999999999,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.17249999999999999,
+    "Alpha Component" : 1,
+    "Green Component" : 0.1333
+  },
   "Ambiguous Double Width" : false,
+  "Option Key Sends" : 2,
+  "Ansi 3 Color" : {
+    "Red Component" : 0.78058648109436035,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.76959484815597534
+  },
+  "Window Type" : 0,
+  "BM Growl" : true,
+  "Prompt Before Closing 2" : false,
+  "Command" : "",
+  "Selected Text Color" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0
+  },
+  "Ansi 14 Color (Light)" : {
+    "Red Component" : 0.6431,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Cursor Guide Color (Dark)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
+  },
+  "Send Code When Idle" : false,
+  "Ansi 6 Color" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78166204690933228,
+    "Alpha Component" : 1,
+    "Green Component" : 0.77425903081893921
+  },
   "Jobs to Ignore" : [
     "rlogin",
     "ssh",
     "slogin",
     "telnet"
   ],
-  "Ansi 15 Color" : {
-    "Red Component" : 0.89951915324697673,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.88108618721458776,
-    "Alpha Component" : 1,
-    "Green Component" : 0.90063850687007707
+  "Badge Color (Dark)" : {
+    "Red Component" : 0.92929404973983765,
+    "Color Space" : "P3",
+    "Blue Component" : 0.13960540294647217,
+    "Alpha Component" : 0.5,
+    "Green Component" : 0.25479039549827576
   },
-  "Foreground Color" : {
-    "Red Component" : 0.70869048285965963,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.70869048285965963,
-    "Alpha Component" : 1,
-    "Green Component" : 0.70869048285965963
-  },
-  "Working Directory" : "\/Users\/hcarlin",
-  "Blinking Cursor" : false,
-  "Disable Window Resizing" : true,
-  "Sync Title" : false,
-  "Prompt Before Closing 2" : false,
-  "BM Growl" : true,
-  "Command" : "",
-  "Description" : "Default",
-  "Mouse Reporting" : true,
-  "Screen" : -1,
-  "Selection Color" : {
+  "Cursor Color" : {
     "Red Component" : 0,
     "Color Space" : "sRGB",
-    "Blue Component" : 0.13333333333333333,
+    "Blue Component" : 0,
     "Alpha Component" : 1,
-    "Green Component" : 0.74509803921568629
+    "Green Component" : 0
   },
-  "Columns" : 80,
-  "Idle Code" : 0,
-  "Ansi 13 Color" : {
-    "Red Component" : 0.44809435186589047,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.61578679084777832,
+  "Vertical Spacing" : 1,
+  "Disable Window Resizing" : true,
+  "Close Sessions On End" : true,
+  "Selection Color (Dark)" : {
+    "Red Component" : 0.26669999999999999,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.35289999999999999,
     "Alpha Component" : 1,
-    "Green Component" : 0.3435349775055469
+    "Green Component" : 0.27839999999999998
+  },
+  "Default Bookmark" : "No",
+  "Foreground Color (Light)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
   },
   "Custom Command" : "No",
-  "ASCII Anti Aliased" : true,
-  "Non Ascii Font" : "Monaco 12",
-  "Vertical Spacing" : 1,
-  "Use Bold Font" : true,
-  "Option Key Sends" : 2,
-  "Selected Text Color" : {
+  "Background Color (Dark)" : {
+    "Red Component" : 0.15690000000000001,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.21179999999999999,
+    "Alpha Component" : 1,
+    "Green Component" : 0.16470000000000001
+  },
+  "Ansi 9 Color" : {
+    "Red Component" : 0.8659515380859375,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.45833224058151245,
+    "Alpha Component" : 1,
+    "Green Component" : 0.47524076700210571
+  },
+  "Ansi 14 Color" : {
+    "Red Component" : 0.37597531080245972,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.99263292551040649
+  },
+  "Flashing Bell" : false,
+  "Use Italic Font" : true,
+  "Ansi 13 Color (Dark)" : {
     "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.87450000000000006,
+    "Alpha Component" : 1,
+    "Green Component" : 0.57250000000000001
+  },
+  "Cursor Guide Color (Light)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
+  },
+  "Ansi 12 Color" : {
+    "Red Component" : 0.65349078178405762,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.9485321044921875,
+    "Alpha Component" : 1,
+    "Green Component" : 0.67044717073440552
+  },
+  "Ansi 10 Color (Light)" : {
+    "Red Component" : 0.4118,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.58040000000000003,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Non-ASCII Anti Aliased" : true,
+  "Ansi 10 Color" : {
+    "Red Component" : 0.3450070321559906,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.56541937589645386,
+    "Alpha Component" : 1,
+    "Green Component" : 0.9042816162109375
+  },
+  "Foreground Color" : {
+    "Red Component" : 0.062745101749897003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.062745101749897003,
+    "Alpha Component" : 1,
+    "Green Component" : 0.062745101749897003
+  },
+  "Link Color (Light)" : {
+    "Red Component" : 0.14513972401618958,
+    "Color Space" : "P3",
+    "Blue Component" : 0.7093239426612854,
+    "Alpha Component" : 1,
+    "Green Component" : 0.35333043336868286
+  },
+  "Description" : "Default",
+  "Ansi 7 Color (Dark)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
+  },
+  "Sync Title" : false,
+  "Ansi 1 Color" : {
+    "Red Component" : 0.7074432373046875,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.16300037503242493,
+    "Alpha Component" : 1,
+    "Green Component" : 0.23660069704055786
+  },
+  "Name" : "Default",
+  "Transparency" : 0,
+  "Horizontal Spacing" : 1,
+  "Cursor Color (Dark)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
+  },
+  "Ansi 2 Color (Dark)" : {
+    "Red Component" : 0.31369999999999998,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.4824,
+    "Alpha Component" : 1,
+    "Green Component" : 0.98040000000000005
+  },
+  "Ansi 9 Color (Dark)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.43140000000000001,
+    "Alpha Component" : 1,
+    "Green Component" : 0.43140000000000001
+  },
+  "Badge Color" : {
+    "Red Component" : 0.74613857269287109,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.11610633134841919,
+    "Alpha Component" : 0.5,
+    "Green Component" : 0.11610633134841919
+  },
+  "Ansi 13 Color (Light)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.87450000000000006,
+    "Alpha Component" : 1,
+    "Green Component" : 0.57250000000000001
+  },
+  "Idle Code" : 0,
+  "Ansi 4 Color" : {
+    "Red Component" : 0.15404300391674042,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78216177225112915,
+    "Alpha Component" : 1,
+    "Green Component" : 0.26474356651306152
+  },
+  "Bold Color (Dark)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
+  },
+  "Screen" : -1,
+  "Ansi 4 Color (Dark)" : {
+    "Red Component" : 0.74119999999999997,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.97650000000000003,
+    "Alpha Component" : 1,
+    "Green Component" : 0.57650000000000001
+  },
+  "Cursor Text Color (Dark)" : {
+    "Red Component" : 0.15690000000000001,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.21179999999999999,
+    "Alpha Component" : 1,
+    "Green Component" : 0.16470000000000001
+  },
+  "Selection Color" : {
+    "Red Component" : 0.70196080207824707,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.84313726425170898
+  },
+  "Use Non-ASCII Font" : false,
+  "Badge Color (Light)" : {
+    "Red Component" : 0.92929404973983765,
+    "Color Space" : "P3",
+    "Blue Component" : 0.13960540294647217,
+    "Alpha Component" : 0.5,
+    "Green Component" : 0.25479039549827576
+  },
+  "Character Encoding" : 4,
+  "Ansi 11 Color (Dark)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.64710000000000001,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Bold Color (Light)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
+  },
+  "Ansi 12 Color (Dark)" : {
+    "Red Component" : 0.83919999999999995,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.67449999999999999
+  },
+  "Ansi 7 Color" : {
+    "Red Component" : 0.7810397744178772,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78104829788208008,
+    "Alpha Component" : 1,
+    "Green Component" : 0.78105825185775757
+  },
+  "Non Ascii Font" : "Monaco 12",
+  "Ansi 6 Color (Dark)" : {
+    "Red Component" : 0.54510000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.99219999999999997,
+    "Alpha Component" : 1,
+    "Green Component" : 0.91369999999999996
+  },
+  "Cursor Guide Color" : {
+    "Red Component" : 0.52338260412216187,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.85319280624389648,
+    "Alpha Component" : 0.25,
+    "Green Component" : 0.77217715978622437
+  },
+  "Custom Directory" : "No",
+  "Working Directory" : "\/Users\/hcarlin",
+  "ASCII Anti Aliased" : true,
+  "Shortcut" : "",
+  "Mouse Reporting" : true,
+  "Tags" : [
+
+  ],
+  "Ansi 6 Color (Light)" : {
+    "Red Component" : 0.54510000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.99219999999999997,
+    "Alpha Component" : 1,
+    "Green Component" : 0.91369999999999996
+  },
+  "Match Background Color (Light)" : {
+    "Red Component" : 0.99697142839431763,
+    "Color Space" : "P3",
+    "Blue Component" : 0.32116127014160156,
+    "Alpha Component" : 1,
+    "Green Component" : 0.98600882291793823
+  },
+  "Background Image Location" : "",
+  "Ansi 1 Color (Light)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.33329999999999999,
+    "Alpha Component" : 1,
+    "Green Component" : 0.33329999999999999
+  },
+  "Use Bold Font" : true,
+  "Ansi 8 Color (Light)" : {
+    "Red Component" : 0.38429999999999997,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.6431,
+    "Alpha Component" : 1,
+    "Green Component" : 0.4471
+  },
+  "Ansi 2 Color" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.7607843279838562
+  },
+  "Normal Font" : "Monaco 12",
+  "Unlimited Scrollback" : false,
+  "Ansi 12 Color (Light)" : {
+    "Red Component" : 0.83919999999999995,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.67449999999999999
+  },
+  "Ansi 10 Color (Dark)" : {
+    "Red Component" : 0.4118,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.58040000000000003,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Ansi 3 Color (Light)" : {
+    "Red Component" : 0.94510000000000005,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.54900000000000004,
+    "Alpha Component" : 1,
+    "Green Component" : 0.98040000000000005
+  },
+  "Cursor Color (Light)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
+  },
+  "Ansi 15 Color" : {
+    "Red Component" : 0.99999600648880005,
     "Color Space" : "sRGB",
     "Blue Component" : 1,
     "Alpha Component" : 1,
     "Green Component" : 1
   },
-  "Background Color" : {
-    "Red Component" : 0.10588235408067703,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.11764705926179886,
-    "Alpha Component" : 1,
-    "Green Component" : 0.11372549086809158
-  },
-  "Character Encoding" : 4,
-  "Ansi 11 Color" : {
-    "Red Component" : 0.22747777153716467,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.084493138750657962,
-    "Alpha Component" : 1,
-    "Green Component" : 0.99607843160629272
-  },
-  "Use Italic Font" : true,
-  "Unlimited Scrollback" : false,
-  "Keyboard Map" : {
-    "0xf700-0x260000" : {
-      "Text" : "[1;6A",
-      "Action" : 10
-    },
-    "0x37-0x40000" : {
-      "Text" : "0x1f",
-      "Action" : 11
-    },
-    "0x32-0x40000" : {
-      "Text" : "0x00",
-      "Action" : 11
-    },
-    "0xf709-0x20000" : {
-      "Text" : "[17;2~",
-      "Action" : 10
-    },
-    "0xf70c-0x20000" : {
-      "Text" : "[20;2~",
-      "Action" : 10
-    },
-    "0xf729-0x20000" : {
-      "Text" : "[1;2H",
-      "Action" : 10
-    },
-    "0xf72b-0x40000" : {
-      "Text" : "[1;5F",
-      "Action" : 10
-    },
-    "0xf705-0x20000" : {
-      "Text" : "[1;2Q",
-      "Action" : 10
-    },
-    "0xf703-0x260000" : {
-      "Text" : "[1;6C",
-      "Action" : 10
-    },
-    "0xf700-0x220000" : {
-      "Text" : "[1;2A",
-      "Action" : 10
-    },
-    "0xf701-0x280000" : {
-      "Text" : "0x1b 0x1b 0x5b 0x42",
-      "Action" : 11
-    },
-    "0x38-0x40000" : {
-      "Text" : "0x7f",
-      "Action" : 11
-    },
-    "0x33-0x40000" : {
-      "Text" : "0x1b",
-      "Action" : 11
-    },
-    "0xf703-0x220000" : {
-      "Text" : "[1;2C",
-      "Action" : 10
-    },
-    "0xf701-0x240000" : {
-      "Text" : "[1;5B",
-      "Action" : 10
-    },
-    "0xf70d-0x20000" : {
-      "Text" : "[21;2~",
-      "Action" : 10
-    },
-    "0xf702-0x260000" : {
-      "Text" : "[1;6D",
-      "Action" : 10
-    },
-    "0xf729-0x40000" : {
-      "Text" : "[1;5H",
-      "Action" : 10
-    },
-    "0xf706-0x20000" : {
-      "Text" : "[1;2R",
-      "Action" : 10
-    },
-    "0x34-0x40000" : {
-      "Text" : "0x1c",
-      "Action" : 11
-    },
-    "0xf700-0x280000" : {
-      "Text" : "0x1b 0x1b 0x5b 0x41",
-      "Action" : 11
-    },
-    "0x2d-0x40000" : {
-      "Text" : "0x1f",
-      "Action" : 11
-    },
-    "0xf70e-0x20000" : {
-      "Text" : "[23;2~",
-      "Action" : 10
-    },
-    "0xf702-0x220000" : {
-      "Text" : "[1;2D",
-      "Action" : 10
-    },
-    "0xf703-0x280000" : {
-      "Text" : "f",
-      "Action" : 10
-    },
-    "0xf700-0x240000" : {
-      "Text" : "[1;5A",
-      "Action" : 10
-    },
-    "0xf707-0x20000" : {
-      "Text" : "[1;2S",
-      "Action" : 10
-    },
-    "0xf70a-0x20000" : {
-      "Text" : "[18;2~",
-      "Action" : 10
-    },
-    "0x35-0x40000" : {
-      "Text" : "0x1d",
-      "Action" : 11
-    },
-    "0xf70f-0x20000" : {
-      "Text" : "[24;2~",
-      "Action" : 10
-    },
-    "0xf703-0x240000" : {
-      "Text" : "[1;5C",
-      "Action" : 10
-    },
-    "0xf701-0x260000" : {
-      "Text" : "[1;6B",
-      "Action" : 10
-    },
-    "0xf702-0x280000" : {
-      "Text" : "b",
-      "Action" : 10
-    },
-    "0xf72b-0x20000" : {
-      "Text" : "[1;2F",
-      "Action" : 10
-    },
-    "0x36-0x40000" : {
-      "Text" : "0x1e",
-      "Action" : 11
-    },
-    "0xf708-0x20000" : {
-      "Text" : "[15;2~",
-      "Action" : 10
-    },
-    "0xf701-0x220000" : {
-      "Text" : "[1;2B",
-      "Action" : 10
-    },
-    "0xf70b-0x20000" : {
-      "Text" : "[19;2~",
-      "Action" : 10
-    },
-    "0xf702-0x240000" : {
-      "Text" : "[1;5D",
-      "Action" : 10
-    },
-    "0xf704-0x20000" : {
-      "Text" : "[1;2P",
-      "Action" : 10
-    }
-  },
-  "Window Type" : 0,
-  "Cursor Boost" : 0,
-  "Background Image Location" : "",
   "Blur" : false,
-  "Badge Color" : {
+  "Use Separate Colors for Light and Dark Mode" : true,
+  "Background Color (Light)" : {
+    "Red Component" : 0.15690000000000001,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.21179999999999999,
+    "Alpha Component" : 1,
+    "Green Component" : 0.16470000000000001
+  },
+  "Terminal Type" : "xterm-256color",
+  "Ansi 13 Color" : {
+    "Red Component" : 0.8821563720703125,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.8821563720703125,
+    "Alpha Component" : 1,
+    "Green Component" : 0.4927266538143158
+  },
+  "Ansi 5 Color (Light)" : {
     "Red Component" : 1,
     "Color Space" : "sRGB",
+    "Blue Component" : 0.77649999999999997,
+    "Alpha Component" : 1,
+    "Green Component" : 0.47449999999999998
+  },
+  "Foreground Color (Dark)" : {
+    "Red Component" : 0.97250000000000003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94899999999999995,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97250000000000003
+  },
+  "Link Color" : {
+    "Red Component" : 0.19802422821521759,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.9337158203125,
+    "Alpha Component" : 1,
+    "Green Component" : 0.55789834260940552
+  },
+  "Link Color (Dark)" : {
+    "Red Component" : 0.14513972401618958,
+    "Color Space" : "P3",
+    "Blue Component" : 0.7093239426612854,
+    "Alpha Component" : 1,
+    "Green Component" : 0.35333043336868286
+  },
+  "Ansi 11 Color" : {
+    "Red Component" : 0.9259033203125,
+    "Color Space" : "sRGB",
     "Blue Component" : 0,
-    "Alpha Component" : 0.5,
-    "Green Component" : 0.1491314172744751
-  },
-  "Scrollback Lines" : 1000,
-  "Send Code When Idle" : false,
-  "Close Sessions On End" : true,
-  "Terminal Type" : "xterm-256color",
-  "Visual Bell" : true,
-  "Flashing Bell" : false,
-  "Silence Bell" : false,
-  "Ansi 14 Color" : {
-    "Red Component" : 0.24905191766012108,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.65043008327484131,
     "Alpha Component" : 1,
-    "Green Component" : 0.52346439493942787
-  },
-  "Name" : "Default",
-  "Cursor Text Color" : {
-    "Red Component" : 0,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0,
-    "Alpha Component" : 1,
-    "Green Component" : 0
-  },
-  "Shortcut" : "",
-  "Cursor Color" : {
-    "Red Component" : 0.085739121173077762,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.10552165223418888,
-    "Alpha Component" : 1,
-    "Green Component" : 0.71403488005050497
-  },
-  "Transparency" : 0,
-  "Ansi 1 Color" : {
-    "Red Component" : 0.14859966266501204,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.10479331370389963,
-    "Alpha Component" : 1,
-    "Green Component" : 0.61602351641414144
-  },
-  "Ansi 2 Color" : {
-    "Red Component" : 0.076066421435449241,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.18748788858792831,
-    "Alpha Component" : 1,
-    "Green Component" : 0.80896861625440186
-  },
-  "Ansi 3 Color" : {
-    "Red Component" : 0.3865539065781804,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.34051559260389674,
-    "Alpha Component" : 1,
-    "Green Component" : 0.89520202020202022
-  },
-  "Ansi 4 Color" : {
-    "Red Component" : 0.14491494616547587,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.96046402899905892,
-    "Alpha Component" : 1,
-    "Green Component" : 0.14368117055782587
+    "Green Component" : 0.8833775520324707
   },
   "Ansi 5 Color" : {
-    "Red Component" : 0.39400643977398675,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.4533420205116272,
+    "Red Component" : 0.752197265625,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.74494361877441406,
     "Alpha Component" : 1,
-    "Green Component" : 0.12110199730923903
+    "Green Component" : 0.24931684136390686
   },
-  "Use Non-ASCII Font" : false,
-  "Ansi 6 Color" : {
-    "Red Component" : 0.21641787704792639,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.66414140149800471,
+  "Ansi 0 Color (Light)" : {
+    "Red Component" : 0.12939999999999999,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.17249999999999999,
     "Alpha Component" : 1,
-    "Green Component" : 0.54991022034746728
-  },
-  "Normal Font" : "Monaco 12",
-  "Custom Directory" : "No",
-  "Ansi 0 Color" : {
-    "Red Component" : 0.10588235408067703,
-    "Color Space" : "Calibrated",
-    "Blue Component" : 0.11764705926179886,
-    "Alpha Component" : 1,
-    "Green Component" : 0.11372549086809158
-  },
-  "Guid" : "2400C5B0-EA2B-4139-85DB-E4D01F50B709"
+    "Green Component" : 0.1333
+  }
 }

--- a/apps/raycast/scripts/dedent.sh
+++ b/apps/raycast/scripts/dedent.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# @raycast.schemaVersion 1
+# @raycast.title Dedent
+# @raycast.description Remove Leading Spaces
+# @raycast.mode silent
+# @raycast.icon ✂️
+
+pbpaste | sed 's/^[[:space:]]*//' | pbcopy
+echo "Cleaned!"


### PR DESCRIPTION
The iTerm2 profile needed light/dark mode support with separate color schemes and updated sRGB color values. The dedent Raycast script strips leading whitespace from clipboard content for quick text cleanup.