### PR TITLE
Add nwt helper to run nbd dev in worktrees

### DIFF
--- a/.functions
+++ b/.functions
@@ -62,6 +62,35 @@ function bwt() {
 }
 
 ##
+# Start an nbd dev server. Run from the checkout root or its `nbd` subdir.
+# In a worktree (.worktrees/<name>) it routes via BEND_WORKTREE=<name>;
+# in the main checkout it serves the main checkout with no routing.
+function nwt() {
+  # Resolve the checkout root whether we're at the root or inside the nbd subdir
+  local root
+  if [[ "$(basename "$PWD")" == "nbd" ]]; then
+    root=$(dirname "$PWD")
+  else
+    root="$PWD"
+  fi
+
+  # BEND_WORKTREE tells nbd to route requests to this worktree instead of the main checkout
+  local workspace_name=""
+  if [[ "$(basename "$(dirname "$root")")" == ".worktrees" ]]; then
+    workspace_name=$(basename "$root")
+  fi
+
+  (
+    cd "$root/nbd" || return 1
+    if [[ -n "$workspace_name" ]]; then
+      pnpm install && BEND_WORKTREE="$workspace_name" nbd dev
+    else
+      pnpm install && nbd dev
+    fi
+  )
+}
+
+##
 # Create a new git worktree from the current branch
 # Sample usage:
 #   - create_worktree


### PR DESCRIPTION
## What problem does this solve?

Starting the local dev server against a specific git worktree means setting the right routing env var by hand, which is easy to get wrong. This adds a small shell helper that figures it out from the directory layout.

## Links

None.

## Details

Adds the `nwt` function to `.functions`, mirroring the existing `bwt` helper.

- **Key changes**: new `nwt` in `.functions` that runs `pnpm install && nbd dev` inside the `nbd/` subdir.
- Resolves the checkout root whether invoked from the root or from inside the `nbd/` subdir.
- When the checkout lives under `.worktrees/<name>`, it sets `BEND_WORKTREE=<name>` so requests route to that worktree; in the main checkout it runs with no routing.
- Runs in a subshell so the caller's working directory is left unchanged.

## Testing done / screenshots

Sourced `.functions` and ran `nwt` from each of the four entry points (worktree root, worktree `nbd/` subdir, main checkout root, main checkout `nbd/` subdir), confirming the resolved directory and routing var were correct in each case.